### PR TITLE
Fix login check for deleted users

### DIFF
--- a/login.php
+++ b/login.php
@@ -8,8 +8,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $username = $_POST['username'];
     $password = $_POST['password'];
 
-    // Consulta o usuário no banco de dados
-    $stmt = $pdo->prepare("SELECT * FROM usuarios WHERE username = ?");
+    // Consulta o usuário ativo no banco de dados
+    $stmt = $pdo->prepare("SELECT * FROM usuarios WHERE username = ? AND is_deleted = FALSE");
     $stmt->execute([$username]);
     $user = $stmt->fetch();
 


### PR DESCRIPTION
## Summary
- prevent logically deleted users from signing in

## Testing
- `php -l login.php`
- `find . -name '*.php' -print -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_684b9bc333608327a31611968f97d645