### PR TITLE
Fix filtering of deleted categories

### DIFF
--- a/categorias/delete_category.php
+++ b/categorias/delete_category.php
@@ -10,7 +10,7 @@ include '../db.php';
 $id = $_GET['id'];
 $deleted_by = $_SESSION['user_id'];
 
-$sql = "UPDATE categorias SET deleted_at = NOW(), deleted_by = ? WHERE id = ?";
+$sql = "UPDATE categorias SET deleted_at = NOW(), deleted_by = ?, is_deleted = TRUE WHERE id = ?";
 $stmt = $pdo->prepare($sql);
 $stmt->execute([$deleted_by, $id]);
 

--- a/categorias/edit_category.php
+++ b/categorias/edit_category.php
@@ -9,10 +9,15 @@ include '../db.php';
 include '../utils/image_utils.php'; // Inclui a função de processamento de imagem
 
 $id = $_GET['id'];
-$sql = "SELECT * FROM categorias WHERE id = ?";
+$sql = "SELECT * FROM categorias WHERE id = ? AND is_deleted = FALSE";
 $stmt = $pdo->prepare($sql);
 $stmt->execute([$id]);
 $categoria = $stmt->fetch();
+
+if (!$categoria) {
+    header("Location: list_categories.php");
+    exit();
+}
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];

--- a/categorias/list_categories.php
+++ b/categorias/list_categories.php
@@ -7,8 +7,8 @@ if (!isset($_SESSION['user_id'])) {
 
 include '../db.php';
 
-// Consulta para obter todas as categorias
-$sql = "SELECT * FROM categorias WHERE deleted_at IS NULL";
+// Consulta para obter todas as categorias ativas
+$sql = "SELECT * FROM categorias WHERE is_deleted = FALSE";
 $stmt = $pdo->prepare($sql);
 $stmt->execute();
 $categorias = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -36,7 +36,7 @@ $categorias = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <?php foreach ($categorias as $categoria): ?>
             <tr>
                 <td><?php echo htmlspecialchars($categoria['nome']); ?></td>
-                <td><img src="../uploads/<?php echo htmlspecialchars($categoria['imagem_categoria'] ?? 'default_category.png'); ?>" width="50" /></td>
+                <td><img src="../uploads/<?php echo htmlspecialchars($categoria['imagem_categoria'] ?? 'default.webp'); ?>" width="50" /></td>
                 <td>
                     <a href="edit_category.php?id=<?php echo $categoria['id']; ?>">Editar</a> |
                     <a href="delete_category.php?id=<?php echo $categoria['id']; ?>" onclick="return confirm('Tem certeza que deseja excluir esta categoria?');">Excluir</a>

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@ $date_start = $_GET['date_start'] ?? '';
 $date_end = $_GET['date_end'] ?? '';
 
 // Consulta para obter categorias para o filtro
-$category_stmt = $pdo->prepare("SELECT * FROM categorias");
+$category_stmt = $pdo->prepare("SELECT * FROM categorias WHERE is_deleted = FALSE");
 $category_stmt->execute();
 $categories = $category_stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -113,7 +113,7 @@ $itens = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <td><?php echo htmlspecialchars($item['nome']); ?></td>
                 <td><?php echo htmlspecialchars($item['descricao']); ?></td>
                 <td><?php echo htmlspecialchars($item['categoria_nome']); ?></td>
-                <td><img src="uploads/<?php echo htmlspecialchars($item['foto']) ? htmlspecialchars($item['foto']) : 'default.png'; ?>" alt="Imagem do Item" width="50" onclick="openModal(this.src)" style="cursor: pointer;"/></td>
+                <td><img src="uploads/<?php echo htmlspecialchars($item['foto']) ? htmlspecialchars($item['foto']) : 'default.webp'; ?>" alt="Imagem do Item" width="50" onclick="openModal(this.src)" style="cursor: pointer;"/></td>
                 <td><?php echo date("d/m/Y", strtotime($item['created_at'])); ?></td>
             </tr>
             <?php endforeach; ?>

--- a/itens/add_item.php
+++ b/itens/add_item.php
@@ -50,7 +50,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 }
 
 // Obter categorias para o campo de seleção
-$category_stmt = $pdo->prepare("SELECT * FROM categorias");
+$category_stmt = $pdo->prepare("SELECT * FROM categorias WHERE is_deleted = FALSE");
 $category_stmt->execute();
 $categories = $category_stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>

--- a/itens/edit_item.php
+++ b/itens/edit_item.php
@@ -9,10 +9,16 @@ include '../db.php';
 include '../utils/image_utils.php'; // Inclui a função de processamento de imagem
 
 $id = $_GET['id'];
-$sql = "SELECT * FROM itens WHERE id = ?";
+$sql = "SELECT * FROM itens WHERE id = ? AND is_deleted = FALSE";
 $stmt = $pdo->prepare($sql);
 $stmt->execute([$id]);
 $item = $stmt->fetch();
+
+// Redireciona se o item não existir ou estiver excluído
+if (!$item) {
+    header("Location: list_items.php");
+    exit();
+}
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];
@@ -45,7 +51,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 }
 
 // Obter categorias para o campo de seleção
-$category_stmt = $pdo->prepare("SELECT * FROM categorias");
+$category_stmt = $pdo->prepare("SELECT * FROM categorias WHERE is_deleted = FALSE");
 $category_stmt->execute();
 $categories = $category_stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>

--- a/itens/list_items.php
+++ b/itens/list_items.php
@@ -9,7 +9,7 @@ $date_start = $_GET['date_start'] ?? '';
 $date_end = $_GET['date_end'] ?? '';
 
 // Consulta para obter categorias para o filtro
-$category_stmt = $pdo->prepare("SELECT * FROM categorias");
+$category_stmt = $pdo->prepare("SELECT * FROM categorias WHERE is_deleted = FALSE");
 $category_stmt->execute();
 $categories = $category_stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -99,7 +99,7 @@ $itens = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <td><?php echo htmlspecialchars($item['nome']); ?></td>
                 <td><?php echo htmlspecialchars($item['descricao']); ?></td>
                 <td><?php echo htmlspecialchars($item['categoria_nome']); ?></td>
-                <td><img src="../uploads/<?php echo htmlspecialchars($item['foto']) ? htmlspecialchars($item['foto']) : 'default.png'; ?>" alt="Imagem do Item" width="50" onclick="openModal(this.src)" style="cursor: pointer;" /></td>
+                <td><img src="../uploads/<?php echo htmlspecialchars($item['foto']) ? htmlspecialchars($item['foto']) : 'default.webp'; ?>" alt="Imagem do Item" width="50" onclick="openModal(this.src)" style="cursor: pointer;" /></td>
                 <td><?php echo date("d/m/Y", strtotime($item['created_at'])); ?></td>
                 <?php if (isset($_SESSION['user_id'])): ?>
                     <td>

--- a/login.php
+++ b/login.php
@@ -8,8 +8,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $username = $_POST['username'];
     $password = $_POST['password'];
 
-    // Consulta o usuário no banco de dados
-    $stmt = $pdo->prepare("SELECT * FROM usuarios WHERE username = ?");
+    // Consulta o usuário ativo no banco de dados
+    $stmt = $pdo->prepare("SELECT * FROM usuarios WHERE username = ? AND is_deleted = FALSE");
     $stmt->execute([$username]);
     $user = $stmt->fetch();
 


### PR DESCRIPTION
## Summary
- ignore removed categories in queries
- show default webp image when no item photo exists
- prevent editing deleted categories/items

## Testing
- `php -l categorias/delete_category.php`
- `php -l categorias/edit_category.php`
- `php -l categorias/list_categories.php`
- `php -l index.php`
- `php -l itens/add_item.php`
- `php -l itens/edit_item.php`
- `php -l itens/list_items.php`
- `find . -name '*.php' -print -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_684b9bc333608327a31611968f97d645