### PR TITLE
Resolve Issue #8 with proper transaction rollback

### DIFF
--- a/itens/delete_item.php
+++ b/itens/delete_item.php
@@ -26,7 +26,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit();
         } catch (Exception $e) {
             $pdo->rollBack();
-            throw $e;
+            registerLog($pdo, $_SESSION['user_id'], $id, 'delete_item_error', $e->getMessage());
+            $error = 'Ocorreu um erro ao tentar excluir o item. Por favor, tente novamente mais tarde.';
         }
     } else {
         $error = 'Confirmação e motivo da exclusão são obrigatórios.';

--- a/itens/delete_item.php
+++ b/itens/delete_item.php
@@ -24,7 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $pdo->commit();
             header("Location: list_items.php");
             exit();
-        } catch (Exception $e) {
+        } catch (PDOException $e) {
             if ($pdo->inTransaction()) {
                 $pdo->rollBack();
             }

--- a/itens/delete_item.php
+++ b/itens/delete_item.php
@@ -16,13 +16,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $confirmed = $_POST['confirmed'] ?? '';
     if ($id && $reason !== '' && $confirmed === '1') {
         $deleted_by = $_SESSION['user_id'];
-        $pdo->beginTransaction();
-        $stmt = $pdo->prepare("UPDATE itens SET deleted_at = NOW(), deleted_by = ?, is_deleted = TRUE WHERE id = ?");
-        $stmt->execute([$deleted_by, $id]);
-        registerLog($pdo, $deleted_by, $id, 'delete_item', $reason);
-        $pdo->commit();
-        header("Location: list_items.php");
-        exit();
+        try {
+            $pdo->beginTransaction();
+            $stmt = $pdo->prepare("UPDATE itens SET deleted_at = NOW(), deleted_by = ?, is_deleted = TRUE WHERE id = ?");
+            $stmt->execute([$deleted_by, $id]);
+            registerLog($pdo, $deleted_by, $id, 'delete_item', $reason);
+            $pdo->commit();
+            header("Location: list_items.php");
+            exit();
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
     } else {
         $error = 'Confirmação e motivo da exclusão são obrigatórios.';
     }

--- a/itens/delete_item.php
+++ b/itens/delete_item.php
@@ -28,7 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($pdo->inTransaction()) {
                 $pdo->rollBack();
             }
-            registerLog($pdo, $_SESSION['user_id'], $id, 'delete_item_error', $e->getMessage());
+            registerLog($pdo, $deleted_by, $id, 'delete_item_error', $e->getMessage());
             $error = 'Ocorreu um erro ao tentar excluir o item. Por favor, tente novamente mais tarde.';
         }
     } else {

--- a/itens/delete_item.php
+++ b/itens/delete_item.php
@@ -25,7 +25,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             header("Location: list_items.php");
             exit();
         } catch (Exception $e) {
-            $pdo->rollBack();
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
             registerLog($pdo, $_SESSION['user_id'], $id, 'delete_item_error', $e->getMessage());
             $error = 'Ocorreu um erro ao tentar excluir o item. Por favor, tente novamente mais tarde.';
         }


### PR DESCRIPTION
## Summary
- ensure delete_item.php rolls back the database transaction on failure
- add try/catch around item deletion and logging

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684bf84d08948327b0350e3103acfa21