### PR TITLE
Add permite_foto feature to categories and update related item handling

### DIFF
--- a/categorias/add_category.php
+++ b/categorias/add_category.php
@@ -13,6 +13,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];
     $created_by = $_SESSION['user_id'];
     $image = 'default.webp';
+    $permite_foto = isset($_POST['permite_foto']) ? 1 : 0;
 
     if (!empty($_FILES['image']['name'])) {
        // Gerar um nome seguro e único para a imagem usando o nome do item
@@ -27,9 +28,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         }
     }
 
-    $sql = "INSERT INTO categorias (nome, imagem_categoria, created_by) VALUES (?, ?, ?)";
+    $sql = "INSERT INTO categorias (nome, imagem_categoria, created_by, permite_foto) VALUES (?, ?, ?, ?)";
     $stmt = $pdo->prepare($sql);
-    $stmt->execute([$name, $image, $created_by]);
+    $stmt->execute([$name, $image, $created_by, $permite_foto]);
     $categoryId = $pdo->lastInsertId(); // Recupera o ID da categoria recém-criada
 
     // Log de criação de categoria
@@ -68,6 +69,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             <label for="image">Imagem Padrão:</label>
             <input type="file" name="image" id="image" accept="image/*">
             <small>Tipos permitidos: JPG, PNG, GIF, WEBP, BMP. Tamanho máximo: 2MB.</small>
+
+            <label for="permite_foto">
+                <input type="checkbox" name="permite_foto" id="permite_foto" checked>
+                Permitir cadastro de fotos para itens desta categoria
+            </label>
 
             <div class="button-container">
                 <button type="submit" class="save-button">Cadastrar Categoria</button>

--- a/categorias/add_category.php
+++ b/categorias/add_category.php
@@ -16,15 +16,21 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $permite_foto = isset($_POST['permite_foto']) ? 1 : 0;
 
     if (!empty($_FILES['image']['name'])) {
-       // Gerar um nome seguro e único para a imagem usando o nome do item
-       $imageName = generateSafeImageName($name);
-       $targetPath = "../uploads/" . $imageName;
+        // Verifica o tamanho do arquivo (10MB = 10 * 1024 * 1024 bytes)
+        if ($_FILES['image']['size'] > 10 * 1024 * 1024) {
+            echo "Erro: O arquivo excede o limite de 2MB.";
+            exit();
+        }
+        // Gerar um nome seguro e único para a imagem usando o nome do item
+        $imageName = generateSafeImageName($name);
+        $targetPath = "../uploads/" . $imageName;
 
         // Processar e salvar a imagem em WebP
         if (processImage($_FILES['image'], $targetPath)) {
             $image = $imageName;
         } else {
             echo "Erro ao processar a imagem.";
+            exit();
         }
     }
 
@@ -68,7 +74,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
             <label for="image">Imagem Padrão:</label>
             <input type="file" name="image" id="image" accept="image/*">
-            <small>Tipos permitidos: JPG, PNG, GIF, WEBP, BMP. Tamanho máximo: 2MB.</small>
+            <small>Tipos permitidos: JPG, PNG, GIF, WEBP, BMP. Tamanho máximo: 10MB.</small>
 
             <label for="permite_foto">
                 <input type="checkbox" name="permite_foto" id="permite_foto" checked>

--- a/categorias/edit_category.php
+++ b/categorias/edit_category.php
@@ -24,6 +24,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $name = $_POST['name'];
     $updated_by = $_SESSION['user_id'];
     $image = $categoria['imagem_categoria']; // Manter a imagem atual por padrão
+    $permite_foto = isset($_POST['permite_foto']) ? 1 : 0;
     $changes = [];
 
     // Verificar alterações
@@ -46,10 +47,15 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         }
     }
 
+    // Verificar se a opção de permitir fotos foi alterada
+    if ($permite_foto != $categoria['permite_foto']) {
+        $changes['permite_foto'] = ['de' => $categoria['permite_foto'], 'para' => $permite_foto];
+    }
+
     // Atualizar a categoria no banco de dados
-    $sql = "UPDATE categorias SET nome = ?, imagem_categoria = ?, updated_at = NOW(), updated_by = ? WHERE id = ?";
+    $sql = "UPDATE categorias SET nome = ?, imagem_categoria = ?, permite_foto = ?, updated_at = NOW(), updated_by = ? WHERE id = ?";
     $stmt = $pdo->prepare($sql);
-    $stmt->execute([$name, $image, $updated_by, $id]);
+    $stmt->execute([$name, $image, $permite_foto, $updated_by, $id]);
 
     // Log de edição de categoria
     logAction($pdo, [
@@ -91,6 +97,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             <label for="image">Imagem (deixe em branco para manter a atual):</label>
             <input type="file" name="image" id="image" accept="image/*">
             <small>Tipos permitidos: JPG, PNG, GIF, WEBP, BMP. Tamanho máximo: 10MB.</small>
+
+            <label for="permite_foto">
+                <input type="checkbox" name="permite_foto" id="permite_foto" value="1" <?php echo ($categoria['permite_foto'] ? 'checked' : ''); ?>>
+                Permitir cadastro de fotos para itens desta categoria
+            </label>
 
             <div class="button-container">
                 <button type="submit" class="save-button">Salvar Alterações</button>

--- a/categorias/list_categories.php
+++ b/categorias/list_categories.php
@@ -31,12 +31,14 @@ $categorias = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <tr>
                 <th>Nome</th>
                 <th>Imagem Padrão</th>
+                <th>Permite Foto?</th>
                 <th>Ações</th>
             </tr>
             <?php foreach ($categorias as $categoria): ?>
             <tr>
                 <td><?php echo htmlspecialchars($categoria['nome']); ?></td>
                 <td><img src="../uploads/<?php echo htmlspecialchars($categoria['imagem_categoria'] ?? 'default.webp'); ?>" width="50" /></td>
+                <td><?php echo $categoria['permite_foto'] ? 'Sim' : 'Não'; ?></td>
                 <td>
                     <a href="edit_category.php?id=<?php echo $categoria['id']; ?>">Editar</a> |
                     <a href="delete_category.php?id=<?php echo $categoria['id']; ?>" onclick="return confirm('Tem certeza que deseja excluir esta categoria?');">Excluir</a>

--- a/itens/edit_item.php
+++ b/itens/edit_item.php
@@ -29,18 +29,22 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $image = $item['foto']; // Mantém a imagem atual por padrão
     $changes = [];
 
-    if ($name !== $item['nome']) {
-        $changes['nome'] = ['de' => $item['nome'], 'para' => $name];
-    }
-    if ($description !== $item['descricao']) {
-        $changes['descricao'] = ['de' => $item['descricao'], 'para' => $description];
-    }
+    // Buscar se a categoria permite foto
+    $catStmt = $pdo->prepare("SELECT imagem_categoria, permite_foto FROM categorias WHERE id = ?");
+    $catStmt->execute([$category_id]);
+    $category = $catStmt->fetch();
+    $permite_foto = $category ? $category['permite_foto'] : 1;
+
     if ($category_id !== $item['categoria_id']) {
         $changes['categoria_id'] = ['de' => $item['categoria_id'], 'para' => $category_id];
+        // Se mudou para uma categoria que não permite foto, zera a foto
+        if ($permite_foto == 0) {
+            $image = $category['imagem_categoria'] ?? 'default.webp';
+            $changes['foto'] = ['de' => $item['foto'], 'para' => $image];
+        }
     }
 
-    // Verificar se o usuário enviou uma nova imagem
-    if (!empty($_FILES['image']['name'])) {
+    if ($permite_foto && !empty($_FILES['image']['name'])) {
         // Gerar um nome seguro e único para a imagem usando o nome do item
         $imageName = generateSafeImageName($name);
         $targetPath = "../uploads/" . $imageName;
@@ -52,6 +56,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         } else {
             echo "Erro ao processar a imagem.";
         }
+    } else if ($permite_foto == 0) {
+        // Se a categoria não permite foto, sempre zera a foto
+        $image = $category['imagem_categoria'] ?? 'default.webp';
     }
 
     // Atualizar o item no banco de dados
@@ -116,6 +123,56 @@ $categories = $category_stmt->fetchAll(PDO::FETCH_ASSOC);
             <label for="image">Imagem (deixe em branco para manter a atual):</label>
             <input type="file" name="image" id="image" accept="image/*">
             <small>Tipos permitidos: JPG, PNG, GIF, WEBP, BMP. Tamanho máximo: 10MB.</small>
+            <script>
+            // Desabilita o campo de imagem se a categoria não permitir foto
+            const categorySelect = document.getElementById('category_id');
+            const imageInput = document.getElementById('image');
+            const categories = <?php echo json_encode($categories); ?>;
+            function updateImageInput() {
+                const selected = categories.find(c => c.id == categorySelect.value);
+                if (selected && selected.permite_foto == 0) {
+                    imageInput.disabled = true;
+                    imageInput.value = '';
+                    imageInput.title = 'Esta categoria não permite cadastro de fotos.';
+                } else {
+                    imageInput.disabled = false;
+                    imageInput.title = '';
+                }
+            }
+            categorySelect.addEventListener('change', updateImageInput);
+            window.addEventListener('DOMContentLoaded', updateImageInput);
+            </script>
+
+            <!-- Adiciona aviso dinâmico se a categoria não permite foto -->
+            <script>
+                document.addEventListener('DOMContentLoaded', function() {
+                    const categorySelect = document.getElementById('category_id');
+                    const imageInput = document.getElementById('image');
+                    const avisoDiv = document.createElement('div');
+                    avisoDiv.id = 'aviso-permite-foto';
+                    avisoDiv.style.color = 'red';
+                    imageInput.parentNode.insertBefore(avisoDiv, imageInput.nextSibling);
+
+                    // Mapeia categorias e se permitem foto
+                    const categoriasPermiteFoto = {};
+                    <?php foreach ($categories as $cat): ?>
+                        categoriasPermiteFoto[<?php echo $cat['id']; ?>] = <?php echo $cat['permite_foto'] ? 'true' : 'false'; ?>;
+                    <?php endforeach; ?>
+
+                    function atualizarAviso() {
+                        const selected = categorySelect.value;
+                        if (categoriasPermiteFoto[selected] === false) {
+                            avisoDiv.textContent = 'Atenção: Esta categoria não permite o cadastro de fotos.';
+                            imageInput.disabled = true;
+                        } else {
+                            avisoDiv.textContent = '';
+                            imageInput.disabled = false;
+                        }
+                    }
+                    categorySelect.addEventListener('change', atualizarAviso);
+                    atualizarAviso();
+                });
+            </script>
 
             <div class="button-container">
                 <button type="submit" class="save-button">Salvar Alterações</button>

--- a/itens/list_items.php
+++ b/itens/list_items.php
@@ -14,7 +14,7 @@ $category_stmt->execute();
 $categories = $category_stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Consulta para listar itens com busca e filtro
-$sql = "SELECT itens.*, categorias.nome AS categoria_nome 
+$sql = "SELECT itens.*, categorias.nome AS categoria_nome, categorias.permite_foto 
         FROM itens 
         LEFT JOIN categorias ON itens.categoria_id = categorias.id 
         WHERE itens.is_deleted = FALSE";
@@ -88,6 +88,7 @@ $itens = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <th>Nome</th>
                 <th>Descrição</th>
                 <th>Categoria</th>
+                <th>Permite Foto?</th>
                 <th>Imagem</th>
                 <th>Data de Cadastro</th>
                 <?php if (isset($_SESSION['user_id'])): ?>
@@ -99,6 +100,7 @@ $itens = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <td><?php echo htmlspecialchars($item['nome']); ?></td>
                 <td><?php echo htmlspecialchars($item['descricao']); ?></td>
                 <td><?php echo htmlspecialchars($item['categoria_nome']); ?></td>
+                <td><?php echo isset($item['permite_foto']) ? ($item['permite_foto'] ? 'Sim' : 'Não') : ''; ?></td>
                 <td><img src="../uploads/<?php echo !empty($item['foto']) ? htmlspecialchars($item['foto']) : 'default.webp'; ?>" alt="Imagem do Item" width="50" onclick="openModal(this.src)" style="cursor: pointer;" /></td>
                 <td><?php echo date("d/m/Y", strtotime($item['created_at'])); ?></td>
                 <?php if (isset($_SESSION['user_id'])): ?>

--- a/sql/database_setup.sql
+++ b/sql/database_setup.sql
@@ -12,11 +12,12 @@ CREATE TABLE IF NOT EXISTS usuarios (
     deleted_by INT DEFAULT NULL
 );
 
--- Tabela de categorias, agora com suporte para imagem padrão
+-- Tabela de categorias, agora com suporte para imagem padrão e controle de permissão de foto
 CREATE TABLE categorias (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nome VARCHAR(50) NOT NULL UNIQUE,
     imagem_categoria VARCHAR(255) DEFAULT 'default.webp',
+    permite_foto BOOLEAN NOT NULL DEFAULT TRUE, -- NOVO: indica se a categoria permite fotos
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by INT DEFAULT NULL,
     updated_at TIMESTAMP NULL DEFAULT NULL,


### PR DESCRIPTION
- Added permite_foto field to categories table to control photo uploads.
- Updated add_category and edit_category forms to include permite_foto checkbox.
- Modified item addition and editing logic to respect permite_foto setting.
- Enhanced list views to display permite_foto status for categories and items.